### PR TITLE
Upgrade github action go-version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.6
+          go-version: 1.17.1
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Upgrade to go-version: 1.17.1 to enable darwin/arm64 release.

Could it be possible to create a new release afterward ? 

This would solve #5 which is opened for month.