### PR TITLE
ForceNew added for optional fields

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     pkcs12 = {
-      source = "chilicat/pkcs12"
+      source  = "chilicat/pkcs12"
       version = "0.1.0"
     }
   }
@@ -18,37 +18,37 @@ resource "tls_private_key" "my_private_key" {
 
 resource "tls_self_signed_cert" "my_cert" {
   # key_algorithm   = tls_private_key.my_private_key.algorithm
-  private_key_pem = tls_private_key.my_private_key.private_key_pem
+  private_key_pem       = tls_private_key.my_private_key.private_key_pem
   validity_period_hours = 58440
-  early_renewal_hours = 5844
+  early_renewal_hours   = 5844
   allowed_uses = [
-      "key_encipherment",
-      "digital_signature",
-      "server_auth",
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
   ]
-  dns_names = [ "myserver1.lcoal", "myserver2.lcoal"]
-  is_ca_certificate = true 
-  set_subject_key_id  = true
+  dns_names          = ["myserver1.lcoal", "myserver2.lcoal"]
+  is_ca_certificate  = true
+  set_subject_key_id = true
 
   subject {
-      common_name  = "myserver.local"
+    common_name = "myserver.local"
   }
 }
 
 resource "pkcs12_from_pem" "my_pkcs12" {
-  password = "mypassword"
-  cert_pem = tls_self_signed_cert.my_cert.cert_pem
-  private_key_pem  = tls_private_key.my_private_key.private_key_pem
+  password        = "mypassword"
+  cert_pem        = tls_self_signed_cert.my_cert.cert_pem
+  private_key_pem = tls_private_key.my_private_key.private_key_pem
   # private_key_pass = "key-pass"
 }
 
 resource "local_file" "result" {
-  filename = "${path.module}/certificates.p12"
-  content_base64     = pkcs12_from_pem.my_pkcs12.result
+  filename       = "${path.module}/certificates.p12"
+  content_base64 = pkcs12_from_pem.my_pkcs12.result
 }
 
 
 output "my_pkcs12" {
-  value = pkcs12_from_pem.my_pkcs12
+  value     = pkcs12_from_pem.my_pkcs12
   sensitive = true
 }

--- a/pkcs12/resource_pkcs12.go
+++ b/pkcs12/resource_pkcs12.go
@@ -40,6 +40,7 @@ func resourcePkcs12() *schema.Resource {
 				Optional:    true,
 				Sensitive:   true,
 				Default:     "",
+				ForceNew:    true,
 				Description: "Private Key password",
 			},
 			"password": {
@@ -54,17 +55,15 @@ func resourcePkcs12() *schema.Resource {
 				Optional:    true,
 				Sensitive:   true,
 				Default:     "",
+				ForceNew:    true,
 				Description: "CA (or list of CAs)",
-				// TODO: All fields are ForceNew or Computed w/out Optional, Update is superfluous
-				// Why is not possible to force new if optional is true?
-				// ForceNew: true,
-
 			},
 			"encoding": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   false,
 				Default:     "modern2023",
+				ForceNew:    true,
 				Description: "Set encoding",
 			},
 


### PR DESCRIPTION
ForceNew added for optional fields, without this the resource does not update the ```result``` attribute at all when these fields are updated.

For example, updating ```ca_pem``` did not create a new resource and so the ```result``` never updated.

Potentially we could have updated the resource rather than delete, recreate, but a delete/recreate seems correct, as it is essentially an entirely new cert that is created.