### PR TITLE
Update go-pkcs12 to newer version to support modern2026 and passwordless encoding

### DIFF
--- a/docs/resources/from_pem.md
+++ b/docs/resources/from_pem.md
@@ -32,7 +32,7 @@ resource "local_file" "result" {
 * `private_key_pem` - (Required) The private key in PEM format
 * `private_key_pass` - (Optional) Password to decrypt private key
 * `ca_pem` - (Optional) The CA (chain) in PEM format
-* `encoding` - (Optional) Defines keystore encoding. Default `modern2023`. Supported: `modern` (latest modern implementation, currently 2023), `modern2023`, `legacyDES` and `legacyRC2`
+* `encoding` - (Optional) Defines keystore encoding. Default `modern2023`. Supported: `modern` (alias for modern2023), `modern2023`, `modern2026`, `legacy` (alias for `legacyDES`), `legacyDES`, `legacyRC2` and `passwordless`.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
-	software.sslmate.com/src/go-pkcs12 v0.4.0
+	software.sslmate.com/src/go-pkcs12 v0.7.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -149,3 +149,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
+software.sslmate.com/src/go-pkcs12 v0.7.1 h1:bxkUPRsvTPNRBZa4M/aSX4PyMOEbq3V8I6hbkG4F4Q8=
+software.sslmate.com/src/go-pkcs12 v0.7.1/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/pkcs12/resource_pkcs12.go
+++ b/pkcs12/resource_pkcs12.go
@@ -155,10 +155,13 @@ func resourcePkcs12Delete(ctx context.Context, d *schema.ResourceData, m interfa
 
 var (
 	encodingMap = map[string]*pkcs12.Encoder{
-		"modern":     pkcs12.Modern,
-		"modern2023": pkcs12.Modern2023,
-		"legacyDES":  pkcs12.LegacyDES,
-		"legacyRC2":  pkcs12.LegacyRC2,
+		"modern":       pkcs12.Modern,
+		"modern2023":   pkcs12.Modern2023,
+		"modern2026":   pkcs12.Modern2026,
+		"legacy":       pkcs12.Legacy,
+		"legacyDES":    pkcs12.LegacyDES,
+		"legacyRC2":    pkcs12.LegacyRC2,
+		"passwordless": pkcs12.Passwordless,
 	}
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -280,7 +280,7 @@ google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
-# software.sslmate.com/src/go-pkcs12 v0.4.0
+# software.sslmate.com/src/go-pkcs12 v0.7.1
 ## explicit; go 1.19
 software.sslmate.com/src/go-pkcs12
 software.sslmate.com/src/go-pkcs12/internal/rc2

--- a/vendor/software.sslmate.com/src/go-pkcs12/mac.go
+++ b/vendor/software.sslmate.com/src/go-pkcs12/mac.go
@@ -9,9 +9,14 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"errors"
+	"fmt"
 	"hash"
+
+	"golang.org/x/crypto/pbkdf2"
 )
 
 type macData struct {
@@ -26,12 +31,124 @@ type digestInfo struct {
 	Digest    []byte
 }
 
+// PBMAC1 parameters structure from RFC 8018
+// When using PBMAC1, the MAC parameters are derived from the algorithm's Parameters field
+// and the macData.MacSalt and macData.Iterations fields are ignored.
+type pbmac1Params struct {
+	Kdf    pkix.AlgorithmIdentifier
+	MacAlg pkix.AlgorithmIdentifier
+}
+
+func makePBMAC1Parameters(salt []byte, iterations int) ([]byte, error) {
+	var err error
+
+	var kdfparams pbkdf2Params
+	if kdfparams.Salt.FullBytes, err = asn1.Marshal(salt); err != nil {
+		return nil, err
+	}
+	kdfparams.Iterations = iterations
+	kdfparams.KeyLength = 32
+	kdfparams.Prf.Algorithm = oidHmacWithSHA256
+
+	var params pbmac1Params
+	params.Kdf.Algorithm = oidPBKDF2
+	if params.Kdf.Parameters.FullBytes, err = asn1.Marshal(kdfparams); err != nil {
+		return nil, err
+	}
+	params.MacAlg.Algorithm = oidHmacWithSHA256
+
+	return asn1.Marshal(params)
+}
+
 var (
 	oidSHA1   = asn1.ObjectIdentifier([]int{1, 3, 14, 3, 2, 26})
 	oidSHA256 = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 1})
+	oidSHA512 = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 3})
+	oidPBMAC1 = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 5, 14})
 )
 
+// doPBMAC1 handles PBMAC1 MAC computation using parameters from Algorithm.Parameters
+// PBMAC1 (RFC 8018) uses PBKDF2 for key derivation and supports various HMAC algorithms.
+// Unlike traditional PKCS#12 MAC algorithms, PBMAC1 gets all its parameters from
+// the Algorithm.Parameters field, ignoring macData.MacSalt and macData.Iterations.
+func doPBMAC1(algorithm pkix.AlgorithmIdentifier, message, password []byte) ([]byte, error) {
+	var params pbmac1Params
+	if err := unmarshal(algorithm.Parameters.FullBytes, &params); err != nil {
+		return nil, fmt.Errorf("error decoding PBMAC1 parameters: %w", err)
+	}
+
+	// Only PBKDF2 is supported as KDF
+	if !params.Kdf.Algorithm.Equal(oidPBKDF2) {
+		return nil, NotImplementedError("PBMAC1 KDF algorithm " + params.Kdf.Algorithm.String() + " is not supported")
+	}
+
+	var kdfParams pbkdf2Params
+	if err := unmarshal(params.Kdf.Parameters.FullBytes, &kdfParams); err != nil {
+		return nil, err
+	}
+
+	if kdfParams.Salt.Tag != asn1.TagOctetString {
+		return nil, NotImplementedError("only octet string salts are supported for PBMAC1/PBKDF2")
+	}
+
+	// Determine PRF function for PBKDF2
+	var prf func() hash.Hash
+	switch {
+	case kdfParams.Prf.Algorithm.Equal(oidHmacWithSHA256):
+		prf = sha256.New
+	case kdfParams.Prf.Algorithm.Equal(oidHmacWithSHA512):
+		prf = sha512.New
+	case kdfParams.Prf.Algorithm.Equal(oidHmacWithSHA1):
+		prf = sha1.New
+	case kdfParams.Prf.Algorithm == nil:
+		// Algorithm not specified; defaults to SHA1 according to ASN1 definition
+		prf = sha1.New
+	default:
+		return nil, NotImplementedError("PBMAC1 PRF " + kdfParams.Prf.Algorithm.String() + " is not supported")
+	}
+
+	// Determine MAC algorithm
+	var hFn func() hash.Hash
+	switch {
+	case params.MacAlg.Algorithm.Equal(oidHmacWithSHA1):
+		hFn = sha1.New
+	case params.MacAlg.Algorithm.Equal(oidHmacWithSHA256):
+		hFn = sha256.New
+	case params.MacAlg.Algorithm.Equal(oidHmacWithSHA512):
+		hFn = sha512.New
+	default:
+		return nil, NotImplementedError("PBMAC1 MAC algorithm " + params.MacAlg.Algorithm.String() + " is not supported")
+	}
+
+	// KeyLength is mandatory in RFC 9579
+	if kdfParams.KeyLength <= 0 {
+		return nil, errors.New("pkcs12: PBMAC1 requires explicit KeyLength parameter in PBKDF2 parameters")
+	}
+	keyLen := kdfParams.KeyLength
+
+	// Derive key using PBKDF2
+	key := pbkdf2.Key(password, kdfParams.Salt.Bytes, kdfParams.Iterations, keyLen, prf)
+
+	// Compute HMAC
+	mac := hmac.New(hFn, key)
+	mac.Write(message)
+	return mac.Sum(nil), nil
+}
+
 func doMac(macData *macData, message, password []byte) ([]byte, error) {
+	// Handle PBMAC1 separately - it uses its own parameters structure from Algorithm.Parameters
+	// and ignores macData.MacSalt and macData.Iterations fields
+	if macData.Mac.Algorithm.Algorithm.Equal(oidPBMAC1) {
+		// PBMAC1 expects UTF-8 passwords (for compatibility; see Erratum 7974), but
+		// PKCS#12 passwords are BMP strings, so we convert the BMP string back to UTF-8
+		originalPassword, err := decodeBMPString(password)
+		if err != nil {
+			return nil, err
+		}
+		utf8Password := []byte(originalPassword)
+		return doPBMAC1(macData.Mac.Algorithm, message, utf8Password)
+	}
+
 	var hFn func() hash.Hash
 	var key []byte
 	switch {
@@ -41,8 +158,11 @@ func doMac(macData *macData, message, password []byte) ([]byte, error) {
 	case macData.Mac.Algorithm.Algorithm.Equal(oidSHA256):
 		hFn = sha256.New
 		key = pbkdf(sha256Sum, 32, 64, macData.MacSalt, password, macData.Iterations, 3, 32)
+	case macData.Mac.Algorithm.Algorithm.Equal(oidSHA512):
+		hFn = sha512.New
+		key = pbkdf(sha512Sum, 64, 128, macData.MacSalt, password, macData.Iterations, 3, 64)
 	default:
-		return nil, NotImplementedError("unknown digest algorithm: " + macData.Mac.Algorithm.Algorithm.String())
+		return nil, NotImplementedError("MAC digest algorithm not supported: " + macData.Mac.Algorithm.Algorithm.String())
 	}
 
 	mac := hmac.New(hFn, key)

--- a/vendor/software.sslmate.com/src/go-pkcs12/pbkdf.go
+++ b/vendor/software.sslmate.com/src/go-pkcs12/pbkdf.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"math/big"
 )
 
@@ -24,6 +25,12 @@ func sha1Sum(in []byte) []byte {
 // sha256Sum returns the SHA-256 hash of in.
 func sha256Sum(in []byte) []byte {
 	sum := sha256.Sum256(in)
+	return sum[:]
+}
+
+// sha512Sum returns the SHA-512 hash of in.
+func sha512Sum(in []byte) []byte {
+	sum := sha512.Sum512(in)
 	return sum[:]
 }
 

--- a/vendor/software.sslmate.com/src/go-pkcs12/pkcs12.go
+++ b/vendor/software.sslmate.com/src/go-pkcs12/pkcs12.go
@@ -38,6 +38,7 @@ const DefaultPassword = "changeit"
 
 // An Encoder contains methods for encoding PKCS#12 files.  This package
 // defines several different Encoders with different parameters.
+// An Encoder is safe for concurrent use by multiple goroutines.
 type Encoder struct {
 	macAlgorithm         asn1.ObjectIdentifier
 	certAlgorithm        asn1.ObjectIdentifier
@@ -156,6 +157,33 @@ var Passwordless = &Encoder{
 // help as much as you think.
 var Modern2023 = &Encoder{
 	macAlgorithm:         oidSHA256,
+	certAlgorithm:        oidPBES2,
+	keyAlgorithm:         oidPBES2,
+	macIterations:        2048,
+	encryptionIterations: 2048,
+	saltLen:              16,
+	rand:                 rand.Reader,
+}
+
+// Modern2026 encodes PKCS#12 files using algorithms that are considered modern
+// as of 2026.  Private keys and certificates are encrypted using PBES2 with
+// PBKDF2-HMAC-SHA-256 and AES-256-CBC.  The MAC algorithm is PBMAC1 with
+// PBKDF2-HMAC-SHA-256 and HMAC-SHA256.
+//
+// Files produced with this encoder can be read by OpenSSL 3.4.0 and higher and
+// Java 26 and higher.
+//
+// For passwords, it is RECOMMENDED that you do one of the following:
+// 1) Use [DefaultPassword] and protect the file using other means, or
+// 2) Use a high-entropy password, such as one generated with `openssl rand -hex 16`.
+//
+// You SHOULD NOT use a lower-entropy password with this encoder because the number of KDF
+// iterations is only 2048 and doesn't provide meaningful protection against
+// brute-forcing.  You can increase the number of iterations using [Encoder.WithIterations],
+// but as https://neilmadden.blog/2023/01/09/on-pbkdf2-iterations/ explains, this doesn't
+// help as much as you think.
+var Modern2026 = &Encoder{
+	macAlgorithm:         oidPBMAC1,
 	certAlgorithm:        oidPBES2,
 	keyAlgorithm:         oidPBES2,
 	macIterations:        2048,
@@ -348,10 +376,10 @@ func convertBag(bag *safeBag, password []byte) (*pem.Block, error) {
 				return nil, err
 			}
 		default:
-			return nil, errors.New("found unknown private key type in PKCS#8 wrapping")
+			return nil, errors.New("pkcs12: found unknown private key type in PKCS#8 wrapping")
 		}
 	default:
-		return nil, errors.New("don't know how to convert a safe bag of type " + bag.Id.String())
+		return nil, errors.New("pkcs12: don't know how to convert a safe bag of type " + bag.Id.String())
 	}
 	return block, nil
 }
@@ -625,7 +653,7 @@ func Encode(rand io.Reader, privateKey interface{}, certificate *x509.Certificat
 // fingerprint of the end-entity certificate.
 func (enc *Encoder) Encode(privateKey interface{}, certificate *x509.Certificate, caCerts []*x509.Certificate, password string) (pfxData []byte, err error) {
 	if enc.macAlgorithm == nil && enc.certAlgorithm == nil && enc.keyAlgorithm == nil && password != "" {
-		return nil, errors.New("password must be empty")
+		return nil, errors.New("pkcs12: password must be empty")
 	}
 
 	encodedPassword, err := bmpStringZeroTerminated(password)
@@ -698,13 +726,21 @@ func (enc *Encoder) Encode(privateKey interface{}, certificate *x509.Certificate
 	}
 
 	if enc.macAlgorithm != nil {
-		// compute the MAC
-		pfx.MacData.Mac.Algorithm.Algorithm = enc.macAlgorithm
-		pfx.MacData.MacSalt = make([]byte, enc.saltLen)
-		if _, err = enc.rand.Read(pfx.MacData.MacSalt); err != nil {
+		macSalt := make([]byte, enc.saltLen)
+		if _, err = enc.rand.Read(macSalt); err != nil {
 			return nil, err
 		}
-		pfx.MacData.Iterations = enc.macIterations
+		pfx.MacData.Mac.Algorithm.Algorithm = enc.macAlgorithm
+		if enc.macAlgorithm.Equal(oidPBMAC1) {
+			var err error
+			pfx.MacData.Mac.Algorithm.Parameters.FullBytes, err = makePBMAC1Parameters(macSalt, enc.macIterations)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			pfx.MacData.MacSalt = macSalt
+			pfx.MacData.Iterations = enc.macIterations
+		}
 		if err = computeMac(&pfx.MacData, authenticatedSafeBytes, encodedPassword); err != nil {
 			return nil, err
 		}
@@ -787,7 +823,7 @@ func EncodeTrustStoreEntries(rand io.Reader, entries []TrustStoreEntry, password
 // encrypted and contains the certificates.
 func (enc *Encoder) EncodeTrustStoreEntries(entries []TrustStoreEntry, password string) (pfxData []byte, err error) {
 	if enc.macAlgorithm == nil && enc.certAlgorithm == nil && password != "" {
-		return nil, errors.New("password must be empty")
+		return nil, errors.New("pkcs12: password must be empty")
 	}
 
 	encodedPassword, err := bmpStringZeroTerminated(password)
@@ -865,13 +901,21 @@ func (enc *Encoder) EncodeTrustStoreEntries(entries []TrustStoreEntry, password 
 	}
 
 	if enc.macAlgorithm != nil {
-		// compute the MAC
-		pfx.MacData.Mac.Algorithm.Algorithm = enc.macAlgorithm
-		pfx.MacData.MacSalt = make([]byte, enc.saltLen)
-		if _, err = enc.rand.Read(pfx.MacData.MacSalt); err != nil {
+		macSalt := make([]byte, enc.saltLen)
+		if _, err = enc.rand.Read(macSalt); err != nil {
 			return nil, err
 		}
-		pfx.MacData.Iterations = enc.macIterations
+		pfx.MacData.Mac.Algorithm.Algorithm = enc.macAlgorithm
+		if enc.macAlgorithm.Equal(oidPBMAC1) {
+			var err error
+			pfx.MacData.Mac.Algorithm.Parameters.FullBytes, err = makePBMAC1Parameters(macSalt, enc.macIterations)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			pfx.MacData.MacSalt = macSalt
+			pfx.MacData.Iterations = enc.macIterations
+		}
 		if err = computeMac(&pfx.MacData, authenticatedSafeBytes, encodedPassword); err != nil {
 			return nil, err
 		}

--- a/vendor/software.sslmate.com/src/go-pkcs12/safebags.go
+++ b/vendor/software.sslmate.com/src/go-pkcs12/safebags.go
@@ -91,7 +91,7 @@ func decodeCertBag(asn1Data []byte) (x509Certificates []byte, err error) {
 		return nil, errors.New("pkcs12: error decoding cert bag: " + err.Error())
 	}
 	if !bag.Id.Equal(oidCertTypeX509Certificate) {
-		return nil, NotImplementedError("only X509 certificates are supported")
+		return nil, NotImplementedError("only X509 certificates are supported in cert bags")
 	}
 	return bag.Data, nil
 }


### PR DESCRIPTION
Adds support for modern2026 and passwordless bags, update go-pkcs12 to latest version for that.
